### PR TITLE
fix: change uart sscanf format specifier from uint8_t to int16_t

### DIFF
--- a/main.c
+++ b/main.c
@@ -346,30 +346,32 @@ void process_command(const char *command)
     }
     else if (strncmp(command, "keyboard_keystroke,", 19) == 0)
     {
+
         // Parse keyboard keystroke command
-        uint8_t code;
-        if (sscanf(command + 19, "%hhu", &code) == 1)
+        int16_t signed_code;
+        if (sscanf(command + 19, "%hd", &signed_code) == 1)
         {
-            hid_report.keystroke = code;
+            hid_report.keystroke = (uint8_t)signed_code; // it did not read the uint8_t with %hhu correctly so had to use %hd and then cast it to uint8_t
         }
     }
     else if (strncmp(command, "keyboard_press,", 15) == 0)
     {
         // Parse keyboard press command
-        uint8_t code;
-        if (sscanf(command + 15, "%hhu", &code) == 1)
+        int16_t signed_code;
+        if (sscanf(command + 15, "%hd", &signed_code) == 1)
         {
             if (hid_report.key_index < MAX_KEYS)
             {
-                hid_report.keys_pressed[hid_report.key_index++] = code;
+                hid_report.keys_pressed[hid_report.key_index++] = (uint8_t)signed_code; // it did not read the uint8_t with %hhu correctly so had to use %hd and then cast it to uint8_t
             }
         }
     }
     else if (strncmp(command, "keyboard_release,", 17) == 0)
     {
-        uint8_t code;
-        if (sscanf(command + 17, "%hhu", &code) == 1)
+        int16_t signed_code;
+        if (sscanf(command + 17, "%hd", &signed_code) == 1)
         {
+            uint8_t code = (uint8_t)signed_code; // it did not read the uint8_t with %hhu correctly so had to use %hd and then cast it to uint8_t
             for (int i = 0; i < hid_report.key_index; i++)
             {
                 if (hid_report.keys_pressed[i] == code)


### PR DESCRIPTION
Changed the format specifier from %hhu to %hd in the sscanf function to read the keycode as int16_t instead of uint8_t. This change was necessary because using %hhu did not work as expected. Additionally, a static cast was added to ensure the signed integer value is correctly assigned to the uint8_t variable.
